### PR TITLE
fix: flatten arrays to _<index>

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,6 +154,17 @@ func flatten(m map[string]interface{}, fields map[string]interface{}, prefix str
 		key := prefix + k
 
 		if v2, ok := v.([]interface{}); ok {
+			if len(v2) == 1 {
+				v20 := v2[0].(string)
+				if ni, err := strconv.ParseInt(v20, 10, 64); err == nil {
+					fields[key+"_0"] = ni
+				} else if nf, err := strconv.ParseFloat(v20, 64); err == nil {
+					fields[key+"_0"] = nf
+				}
+
+				fields[key+"_0"] = v20
+				continue
+			}
 			for i, v := range v2 {
 				fields[key+"_"+strconv.Itoa(i)] = v
 			}

--- a/main.go
+++ b/main.go
@@ -154,19 +154,19 @@ func flatten(m map[string]interface{}, fields map[string]interface{}, prefix str
 		key := prefix + k
 
 		if v2, ok := v.([]interface{}); ok {
-			if len(v2) == 1 {
-				v20 := v2[0].(string)
-				if ni, err := strconv.ParseInt(v20, 10, 64); err == nil {
-					fields[key+"_0"] = ni
-				} else if nf, err := strconv.ParseFloat(v20, 64); err == nil {
-					fields[key+"_0"] = nf
-				}
-
-				fields[key+"_0"] = v20
-				continue
-			}
 			for i, v := range v2 {
-				fields[key+"_"+strconv.Itoa(i)] = v
+				vstr, ok := v.(string)
+				if !ok {
+					fields[key+"_"+strconv.Itoa(i)] = v
+					continue
+				}
+				if ni, err := strconv.ParseInt(vstr, 10, 64); err == nil {
+					fields[key+"_"+strconv.Itoa(i)] = ni
+				} else if nf, err := strconv.ParseFloat(vstr, 64); err == nil {
+					fields[key+"_"+strconv.Itoa(i)] = nf
+				} else {
+					fields[key+"_"+strconv.Itoa(i)] = vstr
+				}
 			}
 		} else if v2, ok := v.(map[string]interface{}); ok {
 			flatten(v2, fields, key+"_")

--- a/main.go
+++ b/main.go
@@ -152,7 +152,11 @@ func flatten(m map[string]interface{}, fields map[string]interface{}, prefix str
 	for k, v := range m {
 		key := prefix + k
 
-		if v2, ok := v.(map[string]interface{}); ok {
+		if v2, ok := v.([]interface{}); ok {
+			for i, v := range v2 {
+				fields[key+"_"+strconv.Itoa(i)] = v
+			}
+		} else if v2, ok := v.(map[string]interface{}); ok {
 			flatten(v2, fields, key+"_")
 		} else {
 			fields[key] = v

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"time"
+	"strconv"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"


### PR DESCRIPTION
This project was not flattening arrays at all which results in it dumping data that looks like, `header: ["value1", "value2"]` into influxdb. 

This patch rectifies the problem by flattening arrays to,

```
header_0: value1
header_1: value2
```

